### PR TITLE
Update strings.json, fixing a title typo

### DIFF
--- a/custom_components/frisquet_connect/strings.json
+++ b/custom_components/frisquet_connect/strings.json
@@ -1,5 +1,5 @@
 {
-    "title": "Frisquest Connect",
+    "title": "Frisquet Connect",
     "config": {
         "flow_title": "Frisquest Connect configuration",
         "step": {


### PR DESCRIPTION
Correct typo in title, from Frisquest to Frisquet