### PR TITLE
Fix reauth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [2.5.2] - 2026-01-22
+
+### Fixed
+- Fix re-authentication error "email/password requis" by moving credentials to the root of the config entry.
+- Added automatic migration (v1 -> v1.2) to fix existing configurations where credentials were hidden in `zone1`.
+- Cleaned up duplicate keys in config flow.
+
+### Added
+- Added "Configure" button support in Home Assistant UI to allow updating email and password without reinstalling.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ _or_
 2- Restart HA and add the integration Frisquet connect from Device -> Add integration<br>
 3- Enter your Username and Password<br>
 
+### Configuration
 
+You can update your email and password at any time by clicking the "Configure" button on the integration page in Home Assistant.
 
 ## Features : Frisquet vs HA logic
 

--- a/custom_components/frisquet_connect/__init__.py
+++ b/custom_components/frisquet_connect/__init__.py
@@ -18,6 +18,36 @@ _LOGGER = logging.getLogger(__name__)
 _LOGGER = logging.getLogger(__name__)
 
 
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug(
+        "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
+    )
+
+    if config_entry.version == 1:
+        new_data = {**config_entry.data}
+
+        # Migration 1.2: Move credentials from zone1 to root if missing
+        if config_entry.minor_version < 2:
+            if "email" not in new_data or "password" not in new_data:
+                if "zone1" in new_data and isinstance(new_data["zone1"], dict):
+                    zone1_data = new_data["zone1"]
+                    if "email" in zone1_data and "password" in zone1_data:
+                        _LOGGER.info("Migration: Moving credentials from zone1 to root")
+                        new_data["email"] = zone1_data["email"]
+                        new_data["password"] = zone1_data["password"]
+            
+            hass.config_entries.async_update_entry(config_entry, data=new_data, minor_version=2)
+
+    _LOGGER.info(
+        "Migration to version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Création des entités à partir d'une configEntry"""
     _LOGGER.debug("In async_setup_entry __init__.py")

--- a/custom_components/frisquet_connect/__init__.py
+++ b/custom_components/frisquet_connect/__init__.py
@@ -90,6 +90,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Charge les plateformes
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Enregistre le listener pour les changements d'options/data
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+
     return True
 
 

--- a/custom_components/frisquet_connect/climate.py
+++ b/custom_components/frisquet_connect/climate.py
@@ -1,5 +1,4 @@
 from .const import DOMAIN, ORDER_API, WS_API
-from .frisquetAPI import FrisquetGetInfo
 import logging
 from zoneinfo import ZoneInfo
 import aiohttp  # type: ignore
@@ -19,7 +18,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback,
-    async_get_current_platform,
 
 )
 
@@ -29,7 +27,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
-    DataUpdateCoordinator,
 )
 
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/custom_components/frisquet_connect/config_flow.py
+++ b/custom_components/frisquet_connect/config_flow.py
@@ -1,6 +1,7 @@
 """ Le Config Flow """
 import logging
-from homeassistant.config_entries import ConfigFlow
+from homeassistant.config_entries import ConfigFlow, OptionsFlow, ConfigEntry
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 import voluptuous as vol
 
@@ -114,3 +115,39 @@ class FrisquetConfigFlow(ConfigFlow, domain=DOMAIN):
         payload["password"] = self.data["password"]
         _LOGGER.debug("Config_Flow payload=%s", payload)
         return self.async_create_entry(title=title, data=payload)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry):
+        return FrisquetOptionsFlowHandler(config_entry)
+
+
+class FrisquetOptionsFlowHandler(OptionsFlow):
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        """Gère les options (configuration des identifiants)."""
+        if user_input is not None:
+            # Mise à jour des identifiants dans config_entry.data
+            # Note: cela déclenchera un reload via update_listener
+            new_data = {**self.config_entry.data, **user_input}
+            # On vide le token pour forcer une ré-auth propre au prochain appel
+            if "token" in new_data:
+                new_data.pop("token")
+            
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, 
+                data=new_data
+            )
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("email", default=self.config_entry.data.get("email")): str,
+                    vol.Required("password", default=self.config_entry.data.get("password")): str,
+                }
+            ),
+        )

--- a/custom_components/frisquet_connect/config_flow.py
+++ b/custom_components/frisquet_connect/config_flow.py
@@ -12,6 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 
 class FrisquetConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
+    MINOR_VERSION = 2
     data: dict = {}
 
     async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
@@ -90,8 +91,6 @@ class FrisquetConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # On force quelques champs utiles dans l'entry
         payload["SiteID"] = site
-        payload["email"] = self.data["email"]
-        payload["password"] = self.data["password"]
         payload["token"] = runtime.get("token") or payload.get("token")
 
         # identifiant_chaudiere au niveau racine (utile pour refresh)

--- a/custom_components/frisquet_connect/manifest.json
+++ b/custom_components/frisquet_connect/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/TheGui01/Friquest-connect-for-home-assistant/issues",
     "quality_scale": "silver",
-    "version": "2.5.1"
+    "version": "2.5.2"
 }

--- a/custom_components/frisquet_connect/sensor.py
+++ b/custom_components/frisquet_connect/sensor.py
@@ -1,15 +1,13 @@
 import logging
-from homeassistant.core import HomeAssistant, callback, Event, State
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.sensor import (
     SensorEntity)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.entity_platform import (
     AddEntitiesCallback)
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,)
-from .climate import FrisquetConnectEntity
 from homeassistant.const import UnitOfEnergy
 from .const import DOMAIN
 

--- a/info.md
+++ b/info.md
@@ -34,7 +34,9 @@ _or_
 2- Restart HA and add the integration Frisquet connect from Device -> Add integration<br>
 3- Enter your Username and Password<br>
 
+### Configuration
 
+You can update your email and password at any time by clicking the "Configure" button on the integration page in Home Assistant.
 
 ## Features : Frisquet vs HA logic
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Frisquet Connect integration for Home Assistant, focusing on user credential management, configuration migration, and UI enhancements. The most significant changes are the addition of an options flow to allow updating credentials from the Home Assistant UI, automatic migration of existing configurations to a more robust format, and various bug fixes related to authentication.

**Credential management and UI enhancements:**

* Added support for the "Configure" button in the Home Assistant UI, enabling users to update their email and password without reinstalling the integration. This is implemented via a new `FrisquetOptionsFlowHandler` in `config_flow.py` and documented in `README.md` and `info.md`. [[1]](diffhunk://#diff-cf0cbb65d9a11300a10aa0331291df3f8cd41f68d281512a7b82315fd452f31dR118-R153) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37-R39)

**Configuration migration and bug fixes:**

* Implemented automatic migration from v1 to v1.2, moving credentials from `zone1` to the root of the config entry if necessary, and cleaning up duplicate keys in the config flow. This ensures existing users are not affected by previous configuration issues.
* Fixed re-authentication errors ("email/password requis") by ensuring credentials are properly stored and accessible in the root of the config entry.

**Versioning and documentation:**

* Updated the integration version to `2.5.2` in `manifest.json` and added a detailed changelog for this release in `CHANGELOG.md`. [[1]](diffhunk://#diff-a1496775e5478165a13db9a75febbf8000318cbe66720709455fac45eb9cae5dL13-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R11)

**Codebase cleanup:**

* Removed unused imports and cleaned up entity platform code in `climate.py` and `sensor.py` to improve maintainability. [[1]](diffhunk://#diff-a839257cc4a0d31fa01de1a1ce367821dad68267934679a38cb3a4bb9427e56cL2) [[2]](diffhunk://#diff-a839257cc4a0d31fa01de1a1ce367821dad68267934679a38cb3a4bb9427e56cL22) [[3]](diffhunk://#diff-a839257cc4a0d31fa01de1a1ce367821dad68267934679a38cb3a4bb9427e56cL32) [[4]](diffhunk://#diff-24bb2f529bfe5e284845b167379d702b2a9e49b3d967f9303f8371e64262691fL2-L12)